### PR TITLE
add proposal template with description

### DIFF
--- a/proposal.md
+++ b/proposal.md
@@ -1,0 +1,16 @@
+# Boardgame Dashboard Proposal
+**Team:** Nathan Smith, Mitch Harris, Ryan Koenig, Sophia Bulcock 
+
+## Motivation and Purpose
+Text here
+
+## Description of the Data
+The proposed dashboard will visualize a dataset of approximately 10,000 boardgames published between 1950 and 2021. The dataset comes from the [Board Game Geek website](https://boardgamegeek.com/) and includes boardgames with descriptions, general game details, publisher, and user ratings. The dataset is available on [Kaggle](https://www.kaggle.com/mshepherd/board-games) and is regularly updated with the latest data.
+
+Numerical game details include features such as min/max players and min/max/ave playing time, while categorical game details include features such as `category` and  `mechanic`. Note that the categorical features can have multiple values. For example, the `mechanic` feature for an individual boardgame may have both "Area Control" and "Area Influence" as values. The publishing information includes `year_published` and features for the `author`, `designer`, and `publisher`. The `publisher` feature is missing the least amount of values in the datasets compared with `author` and `designer`. The user rating features include the boardgame average user rating (`average_rating`) as well as the number of users that have provided a rating (`users_rated`).  There are currently no derived features anticipated for the dataset.
+
+## Research Questions and Usage Scenario
+Text here
+
+## Description of App and Sketch
+Text and image here


### PR DESCRIPTION
added a proposal template that can be used so we're writing into a single document
includes the description section (currently at ~170 words so another sentence or two can be added if required)