### PR TITLE
Speed up first graphs

### DIFF
--- a/src/app/app_graphing.py
+++ b/src/app/app_graphing.py
@@ -26,8 +26,32 @@ def scatter_plot_dates(data, col="category", list_=[None]):
         set_data = app_wr.call_boardgame_radio(data, col, list_)
         set_color = alt.Color("group:N", title="Group")
 
+    reduced_data = set_data.drop(
+        columns=[
+            "Unnamed: 0",
+            "game_id",
+            "image",
+            "max_players",
+            "max_playtime",
+            "min_age",
+            "min_players",
+            "min_playtime",
+            "playing_time",
+            "thumbnail",
+            "artist",
+            "category",
+            "compilation",
+            "designer",
+            "expansion",
+            "family",
+            "mechanic",
+            "publisher",
+            "users_rated",
+        ]
+    )
+
     scatter_plot = (
-        alt.Chart(set_data[["year_published", "average_rating", "name", "group"]])
+        alt.Chart(reduced_data)
         .mark_circle(size=60, opacity=0.2)
         .encode(
             alt.X(
@@ -95,9 +119,33 @@ def count_plot_dates(data, col="category", list_=[None]):
         set_data = app_wr.call_boardgame_radio(data, col, list_)
         set_color = alt.Color("group:N", title="Group")
 
+    reduced_data = set_data.drop(
+        columns=[
+            "Unnamed: 0",
+            "game_id",
+            "image",
+            "max_players",
+            "max_playtime",
+            "min_age",
+            "min_players",
+            "min_playtime",
+            "playing_time",
+            "thumbnail",
+            "artist",
+            "category",
+            "compilation",
+            "designer",
+            "expansion",
+            "family",
+            "mechanic",
+            "publisher",
+            "users_rated",
+        ]
+    )
+
     alt.data_transformers.disable_max_rows()
     count_plot = (
-        alt.Chart(set_data)
+        alt.Chart(reduced_data)
         .mark_bar()
         .encode(
             alt.X(

--- a/src/app/app_graphing.py
+++ b/src/app/app_graphing.py
@@ -26,29 +26,7 @@ def scatter_plot_dates(data, col="category", list_=[None]):
         set_data = app_wr.call_boardgame_radio(data, col, list_)
         set_color = alt.Color("group:N", title="Group")
 
-    reduced_data = set_data.drop(
-        columns=[
-            "Unnamed: 0",
-            "game_id",
-            "image",
-            "max_players",
-            "max_playtime",
-            "min_age",
-            "min_players",
-            "min_playtime",
-            "playing_time",
-            "thumbnail",
-            "artist",
-            "category",
-            "compilation",
-            "designer",
-            "expansion",
-            "family",
-            "mechanic",
-            "publisher",
-            "users_rated",
-        ]
-    )
+    reduced_data = app_wr.remove_columns(set_data)
 
     scatter_plot = (
         alt.Chart(reduced_data)
@@ -119,29 +97,7 @@ def count_plot_dates(data, col="category", list_=[None]):
         set_data = app_wr.call_boardgame_radio(data, col, list_)
         set_color = alt.Color("group:N", title="Group")
 
-    reduced_data = set_data.drop(
-        columns=[
-            "Unnamed: 0",
-            "game_id",
-            "image",
-            "max_players",
-            "max_playtime",
-            "min_age",
-            "min_players",
-            "min_playtime",
-            "playing_time",
-            "thumbnail",
-            "artist",
-            "category",
-            "compilation",
-            "designer",
-            "expansion",
-            "family",
-            "mechanic",
-            "publisher",
-            "users_rated",
-        ]
-    )
+    reduced_data = app_wr.remove_columns(set_data)
 
     alt.data_transformers.disable_max_rows()
     count_plot = (

--- a/src/app/app_graphing.py
+++ b/src/app/app_graphing.py
@@ -27,7 +27,7 @@ def scatter_plot_dates(data, col="category", list_=[None]):
         set_color = alt.Color("group:N", title="Group")
 
     scatter_plot = (
-        alt.Chart(set_data[["year_published", "average_rating", "name"]])
+        alt.Chart(set_data[["year_published", "average_rating", "name", "group"]])
         .mark_circle(size=60, opacity=0.2)
         .encode(
             alt.X(

--- a/src/app/app_graphing.py
+++ b/src/app/app_graphing.py
@@ -27,7 +27,7 @@ def scatter_plot_dates(data, col="category", list_=[None]):
         set_color = alt.Color("group:N", title="Group")
 
     scatter_plot = (
-        alt.Chart(set_data)
+        alt.Chart(set_data[["year_published", "average_rating", "name"]])
         .mark_circle(size=60, opacity=0.2)
         .encode(
             alt.X(

--- a/src/app/app_wrangling.py
+++ b/src/app/app_wrangling.py
@@ -68,7 +68,6 @@ def call_boardgame_filter(data, cat, mech, pub, n):
 
 def call_boardgame_radio(data, col, list_):
     """
-    Wraps call_boardgame_data
     Returns filtered data based on selecting
     'category','mechanic', or 'publisher' column
     and a list of values.
@@ -84,6 +83,8 @@ def call_boardgame_radio(data, col, list_):
     boardgame_data = boardgame_data[call_bool_series_or(col, list_, boardgame_data)]
 
     boardgame_data = form_group(col, list_, boardgame_data)
+
+    boardgame_data = boardgame_data[boardgame_data["group"] != ""]
 
     return boardgame_data
 
@@ -116,12 +117,12 @@ def form_group(col, list_, boardgame_data):
     returns: pandas dataframe
     """
     # takes column and forms new one with appropriate groups
-    boardgame_data[col] = boardgame_data[col].map(lambda x: x.split(","))
+    boardgame_data[col] = list_to_string(boardgame_data[col]).str.split(r",(?![+ ])")
     boardgame_data["group"] = boardgame_data[col].apply(
         lambda x: list(set(x).intersection(set(list_)))
     )
     boardgame_data["group"] = [
-        ",".join(map(str, item)) for item in boardgame_data["group"]
+        ",(?![+ ])".join(map(str, item)) for item in boardgame_data["group"]
     ]
 
     # replaces cross product groups containing all items with generic group
@@ -149,7 +150,7 @@ def call_bool_series_or(col, list_, boardgame_data):
     returns: bool series
     """
     list_ = list_to_string(list_)
-    list_bool = boardgame_data[col].str.match(list_)
+    list_bool = boardgame_data[col].apply(lambda x: any(item in x for item in list_))
 
     return list_bool
 

--- a/src/app/app_wrangling.py
+++ b/src/app/app_wrangling.py
@@ -32,7 +32,6 @@ def call_boardgame_data():
 
 def call_boardgame_filter(data, cat, mech, pub, n):
     """
-    Wraps call_boardgame_data
     Returns filtered data based on list of
     values in 'category', 'mechanic', and
     'publisher' columns.

--- a/src/app/app_wrangling.py
+++ b/src/app/app_wrangling.py
@@ -227,3 +227,35 @@ def subset_data(data, col="category"):
     exp_series = data_copy[col].str.split(r",(?![+ ])").explode()
 
     return list(exp_series.unique())
+
+
+def remove_columns(data):
+    """
+    removes columns unnecessary for plotting first two graphs on tab1
+    hard coded on columns to remove
+    """
+
+    reduced_data = data.drop(
+        columns=[
+            "Unnamed: 0",
+            "game_id",
+            "image",
+            "max_players",
+            "max_playtime",
+            "min_age",
+            "min_players",
+            "min_playtime",
+            "playing_time",
+            "thumbnail",
+            "artist",
+            "category",
+            "compilation",
+            "designer",
+            "expansion",
+            "family",
+            "mechanic",
+            "publisher",
+            "users_rated",
+        ]
+    )
+    return reduced_data


### PR DESCRIPTION
drop unnecessary columns for the first two graphs for noticeable speed ups on heroku

test heroku with this change:
https://test-dashboard-551.herokuapp.com/

our currently deployed heroku:
https://boardgame-dashboard-data551.herokuapp.com/